### PR TITLE
macOS support, zoomable full-res viewer, and release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+# Build self-contained CullPix apps for macOS and Windows. On every push to
+# main a new versioned GitHub Release is published with both downloads. Pull
+# requests (and manual workflow_dispatch runs) build and package on both
+# platforms WITHOUT publishing a release — so changes can be verified first.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS
+            os: macos-latest
+          - name: Windows
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # ---------------------------- macOS ----------------------------
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install qt libraw
+
+      - name: Build & package (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -eux
+          QT_PREFIX="$(brew --prefix qt)"
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$QT_PREFIX;$(brew --prefix libraw)" \
+            -DCULLPIX_MACOS_BUNDLE=ON
+          cmake --build build --config Release --parallel
+          mv build/photo_triage_cpp.app build/CullPix.app
+          # Bundle Qt frameworks + plugins and produce a .dmg.
+          "$QT_PREFIX/bin/macdeployqt" build/CullPix.app -dmg
+          mv build/CullPix.dmg CullPix-macOS-arm64.dmg
+
+      # --------------------------- Windows ---------------------------
+      - name: Install Qt (Windows)
+        if: runner.os == 'Windows'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.8.3'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2022_64'
+
+      - name: Install LibRaw (Windows, vcpkg)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: vcpkg install libraw:x64-windows
+
+      - name: Build & package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          cmake --build build --config Release --parallel
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item build\Release\photo_triage_cpp.exe dist\CullPix.exe
+          # vcpkg's toolchain auto-copies LibRaw (and its deps) next to the exe.
+          Copy-Item build\Release\*.dll dist\ -ErrorAction SilentlyContinue
+          # Bundle the Qt DLLs + plugins (platform, imageformats, styles).
+          windeployqt --release --no-translations dist\CullPix.exe
+          Compress-Archive -Path dist\* -DestinationPath CullPix-Windows-x64.zip -Force
+
+      # --------------------------- Upload ----------------------------
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          if-no-files-found: ignore
+          path: |
+            CullPix-macOS-arm64.dmg
+            CullPix-Windows-x64.zip
+
+  release:
+    name: Publish release
+    needs: build
+    # Only publish on a real push to main; manual runs just build & test.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required to create the release + tag
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v0.0.${{ github.run_number }}
+          name: CullPix v0.0.${{ github.run_number }}
+          generate_release_notes: true
+          files: artifacts/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build output
+/build/
+build/
+out/build/
+
+# macOS
+.DS_Store
+
+# Qt / CMake user files
+CMakeLists.txt.user*
+*.autosave
+CMakeCache.txt
+CMakeFiles/
+
+# IDE
+.idea/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Build the macOS target as a relocatable .app bundle (used by the CI release
+# packaging, which runs macdeployqt + builds a .dmg). Off by default so local
+# dev builds stay a plain, quick-to-launch executable.
+option(CULLPIX_MACOS_BUNDLE "Build the macOS target as an .app bundle" OFF)
+
 # -------- Qt & Threads --------
 find_package(Qt6 REQUIRED COMPONENTS Widgets)
 find_package(Threads REQUIRED)
@@ -39,29 +44,26 @@ elseif (TARGET unofficial::libraw::libraw)
     set(HAVE_LIBRAW TRUE)
     set(LIBRAW_LINK_TARGET unofficial::libraw::libraw)
 else()
-    # Fallbacks: pkg-config or manual
+    # Resolve LibRaw via cached find_path/find_library. Unlike
+    # pkg_check_modules' convenience variables (which can go empty on a cached
+    # reconfigure and silently drop libraw from the compile/link line), the
+    # find_* cache entries persist across reconfigures. pkg-config, when
+    # present, only supplies search hints; CMAKE_PREFIX_PATH covers Homebrew.
     find_package(PkgConfig QUIET)
     if (PkgConfig_FOUND)
-        pkg_check_modules(LIBRAW QUIET libraw)
-        if (LIBRAW_FOUND)
-            message(STATUS "Found LibRaw via pkg-config")
-            set(HAVE_LIBRAW TRUE)
-            # pkg-config gives include dirs & libs below
-            set(LIBRAW_INCLUDE_DIRS ${LIBRAW_INCLUDE_DIRS})
-            set(LIBRAW_LIBRARIES    ${LIBRAW_LIBRARIES})
-        endif()
+        pkg_check_modules(PC_LIBRAW QUIET libraw)
     endif()
-
-    if (NOT HAVE_LIBRAW)
-        # Manual search as a last resort
-        find_path(LIBRAW_INCLUDE_DIR libraw/libraw.h)
-        find_library(LIBRAW_LIBRARY NAMES raw libraw)
-        if (LIBRAW_INCLUDE_DIR AND LIBRAW_LIBRARY)
-            message(STATUS "Found LibRaw via manual search")
-            set(HAVE_LIBRAW TRUE)
-            set(LIBRAW_INCLUDE_DIRS ${LIBRAW_INCLUDE_DIR})
-            set(LIBRAW_LIBRARIES    ${LIBRAW_LIBRARY})
-        endif()
+    find_path(LIBRAW_INCLUDE_DIR
+        NAMES libraw/libraw.h
+        HINTS ${PC_LIBRAW_INCLUDEDIR} ${PC_LIBRAW_INCLUDE_DIRS})
+    find_library(LIBRAW_LIBRARY
+        NAMES raw libraw
+        HINTS ${PC_LIBRAW_LIBDIR} ${PC_LIBRAW_LIBRARY_DIRS})
+    if (LIBRAW_INCLUDE_DIR AND LIBRAW_LIBRARY)
+        message(STATUS "Found LibRaw: ${LIBRAW_LIBRARY}")
+        set(HAVE_LIBRAW TRUE)
+        set(LIBRAW_INCLUDE_DIRS ${LIBRAW_INCLUDE_DIR})
+        set(LIBRAW_LIBRARIES    ${LIBRAW_LIBRARY})
     endif()
 endif()
 
@@ -73,19 +75,34 @@ if (NOT HAVE_LIBRAW)
 endif()
 
 # -------- Sources --------
+# Windows-only resource script (icon). Ignored on other platforms.
+set(PLATFORM_SOURCES "")
+if (WIN32)
+    list(APPEND PLATFORM_SOURCES src/appicon.rc)
+endif()
+
 add_executable(photo_triage_cpp
     src/main.cpp
     src/phototriagewindow.cpp
     src/phototriagewindow.h
     src/imageloader.cpp
     src/imageloader.h
+    src/imageview.cpp
+    src/imageview.h
     src/fileworker.cpp
     src/fileworker.h
     src/rawloader.cpp
     src/rawloader.h
-    src/appicon.rc
+    ${PLATFORM_SOURCES}
     resources/icons.qrc
 )
+
+# Package as a macOS .app bundle only when requested (CI). macdeployqt then
+# bundles the Qt frameworks + image-format plugins so the app runs on machines
+# without Qt installed.
+if (APPLE AND CULLPIX_MACOS_BUNDLE)
+    set_target_properties(photo_triage_cpp PROPERTIES MACOSX_BUNDLE TRUE)
+endif()
 
 # -------- Link libraries --------
 target_link_libraries(photo_triage_cpp
@@ -94,9 +111,9 @@ target_link_libraries(photo_triage_cpp
 )
 
 # Link LibRaw once, after the target exists
-if (LIBRAW_LINK_TARGET)  # imported target (CMake config)
+if (LIBRAW_LINK_TARGET)  # imported target from a real CMake config package
     target_link_libraries(photo_triage_cpp PRIVATE ${LIBRAW_LINK_TARGET})
-else()                   # pkg-config/manual fallback
+else()                   # pkg-config / manual fallback: full lib path + include dir
     target_include_directories(photo_triage_cpp PRIVATE ${LIBRAW_INCLUDE_DIRS})
     target_link_libraries(photo_triage_cpp PRIVATE ${LIBRAW_LIBRARIES})
 endif()

--- a/src/imageloader.cpp
+++ b/src/imageloader.cpp
@@ -14,11 +14,13 @@
 ImageLoader::ImageLoader(int index,
                          const QString &path,
                          QObject *parent,
-                         QSize targetSize)
+                         QSize targetSize,
+                         bool fullQuality)
     : QThread(parent),
     m_index(index),
     m_path(path),
-    m_targetSize(targetSize)
+    m_targetSize(targetSize),
+    m_fullQuality(fullQuality)
 {
     // nothing else
     }
@@ -58,9 +60,16 @@ void ImageLoader::run()
 
     const QString ext = QFileInfo(m_path).suffix();
     const bool isRaw = isRawExtension(ext);
+    // Whether the image we deliver is final display quality. Non-RAW always is;
+    // RAW only when a full demosaic was requested (fast previews get upgraded).
+    const bool achievedFull = m_fullQuality || !isRaw;
 
-    // 1) Try QImageReader (supports scaling and EXIF transforms).
-    {
+    // 1) Try QImageReader (supports scaling and EXIF transforms). Skip it for a
+    //    full-quality RAW request: if a RAW image-format plugin is installed it
+    //    would hand back a baked-in embedded preview here, which we'd then mark
+    //    "full" — silently bypassing the full LibRaw demosaic. Forcing the
+    //    demosaic path keeps the no-quality-loss guarantee plugin-independent.
+    if (!(m_fullQuality && isRaw)) {
         QImageReader reader(m_path);
         reader.setAutoTransform(true); // honor EXIF orientation, etc.
 
@@ -69,7 +78,7 @@ void ImageLoader::run()
         }
 
         if (!isInterruptionRequested() && reader.read(&image) && !image.isNull()) {
-            emit this->loaded(m_index, m_path, image);
+            emit this->loaded(m_index, m_path, image, achievedFull);
             return;
         }
     }
@@ -81,32 +90,40 @@ void ImageLoader::run()
             if (m_targetSize.isValid() && m_targetSize.width() > 0 && m_targetSize.height() > 0) {
                 fallback = fallback.scaled(m_targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
             }
-            emit this->loaded(m_index, m_path, fallback);
+            emit this->loaded(m_index, m_path, fallback, achievedFull);
             return;
         }
     }
 
 #ifdef HAVE_LIBRAW
-    // 3) RAW fallback via LibRaw (fast embedded preview first, then half-size demosaic).
-    if (!isInterruptionRequested()) {
+    // 3) RAW via LibRaw. The current (viewed) image is demosaiced at full
+    //    resolution for maximum quality; the prefetch ring and thumbnails use
+    //    the fast embedded preview, so scrolling a RAW folder never spawns many
+    //    costly concurrent demosaics.
+    if (!isInterruptionRequested() && isRaw) {
         QImage rawImage;
         bool rawLoaded = false; // avoid shadowing the 'loaded' signal
 
-        if (isRaw) {
-            // Try embedded preview (usually a JPEG) – fast and great for thumbnails.
-            if (RawLoader::loadEmbeddedPreview(m_path, rawImage)) {
+        if (m_fullQuality) {
+            // Full-resolution demosaic (max quality). Fall back to the embedded
+            // preview only if the demosaic fails.
+            rawLoaded = RawLoader::loadDemosaiced(m_path, rawImage, /*halfSize=*/false);
+            if (!rawLoaded)
+                rawLoaded = RawLoader::loadEmbeddedPreview(m_path, rawImage);
+        } else {
+            // Fast path: embedded preview (usually a full-size JPEG), with a
+            // half-size demosaic as fallback.
+            if (RawLoader::loadEmbeddedPreview(m_path, rawImage))
                 rawLoaded = true;
-            } else {
-                // Fallback: half-size demosaic for speed/memory.
+            else
                 rawLoaded = RawLoader::loadDemosaiced(m_path, rawImage, /*halfSize=*/true);
-            }
         }
 
         if (rawLoaded && !rawImage.isNull()) {
             if (m_targetSize.isValid() && m_targetSize.width() > 0 && m_targetSize.height() > 0) {
                 rawImage = rawImage.scaled(m_targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
             }
-            emit this->loaded(m_index, m_path, rawImage);
+            emit this->loaded(m_index, m_path, rawImage, m_fullQuality);
             return;
         }
     }
@@ -118,6 +135,6 @@ void ImageLoader::run()
     if (!isInterruptionRequested()) {
         QImage placeholder(100, 100, QImage::Format_RGB32);
         placeholder.fill(QColor("lightgray"));
-        emit this->loaded(m_index, m_path, placeholder);
+        emit this->loaded(m_index, m_path, placeholder, achievedFull);
     }
 }

--- a/src/imageloader.h
+++ b/src/imageloader.h
@@ -18,19 +18,23 @@ class ImageLoader : public QThread
 {
     Q_OBJECT
 public:
-    // Backward-compatible: existing call sites still compile.
+    // fullQuality only affects RAW files: when true the worker does a full,
+    // full-resolution demosaic (maximum quality, slower); when false it uses
+    // the fast embedded preview. Non-RAW formats decode fully either way.
     ImageLoader(int index,
                 const QString &path,
                 QObject *parent = nullptr,
-                QSize targetSize = QSize());
+                QSize targetSize = QSize(),
+                bool fullQuality = false);
     ~ImageLoader() override;
 
 signals:
-    // Emitted when the image has been loaded. The index identifies
-    // which entry in the image list this corresponds to, and the
-    // associated file path is provided to allow keying the cache by
-    // path instead of index.
-    void loaded(int index, const QString &path, const QImage &image);
+    // Emitted when the image has been loaded. The index identifies which entry
+    // in the image list this corresponds to, and the associated file path is
+    // provided to allow keying the cache by path instead of index. fullQuality
+    // reports whether the delivered image is final display quality (a JPEG/PNG
+    // decode, or a full RAW demosaic) versus a fast RAW preview to be upgraded.
+    void loaded(int index, const QString &path, const QImage &image, bool fullQuality);
 
 protected:
     // QThread::run() executes in the worker thread.
@@ -39,5 +43,6 @@ protected:
 private:
     int m_index;
     QString m_path;
-    QSize m_targetSize; // optional decode target, label size.
+    QSize m_targetSize;   // optional decode target (e.g. thumbnail size)
+    bool m_fullQuality;   // RAW: full demosaic vs fast embedded preview
 };

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -1,0 +1,205 @@
+// imageview.cpp
+
+#include "imageview.h"
+
+#include <QGraphicsScene>
+#include <QGraphicsPixmapItem>
+#include <QLabel>
+#include <QImage>
+#include <QPixmap>
+#include <QPainter>
+#include <QColor>
+#include <QWheelEvent>
+#include <QNativeGestureEvent>
+#include <QResizeEvent>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QScrollBar>
+
+ImageView::ImageView(QWidget *parent)
+    : QGraphicsView(parent)
+{
+    m_scene = new QGraphicsScene(this);
+    setScene(m_scene);
+
+    setFrameShape(QFrame::NoFrame);
+    setAlignment(Qt::AlignCenter);
+    // Left-drag pans when zoomed in; harmless at fit.
+    setDragMode(QGraphicsView::ScrollHandDrag);
+    // We anchor zoom manually (see zoomBy) off each event's cursor position,
+    // so no transformation anchor is needed; resizing keeps the view centered.
+    setTransformationAnchor(QGraphicsView::NoAnchor);
+    setResizeAnchor(QGraphicsView::AnchorViewCenter);
+    viewport()->setMouseTracking(true);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setRenderHint(QPainter::SmoothPixmapTransform, true);
+    setBackgroundBrush(QColor("#111111"));
+    setMinimumSize(1, 1);   // never gate the window's minimum size
+
+    m_overlay = new QLabel(viewport());
+    m_overlay->setAlignment(Qt::AlignCenter);
+    m_overlay->setStyleSheet("color:#E0E0E0; background-color:#111111;");
+    m_overlay->hide();
+}
+
+qreal ImageView::deviceScale() const
+{
+    return devicePixelRatioF();
+}
+
+qreal ImageView::fitScale() const
+{
+    if (!m_item)
+        return 1.0;
+    const QSizeF img = m_item->boundingRect().size();
+    const QSize vp = viewport()->size();
+    if (img.width() <= 0.0 || img.height() <= 0.0)
+        return 1.0;
+    return qMin(vp.width() / img.width(), vp.height() / img.height());
+}
+
+void ImageView::setImage(const QImage &image)
+{
+    if (image.isNull()) {
+        showMessage(tr("Unable to load image"));
+        return;
+    }
+    QPixmap pm = QPixmap::fromImage(image);
+    pm.setDevicePixelRatio(1.0);   // scene units == raw image pixels
+    if (!m_item) {
+        m_item = m_scene->addPixmap(pm);
+    } else {
+        m_item->setPixmap(pm);
+    }
+    m_scene->setSceneRect(m_item->boundingRect());
+
+    m_overlay->hide();
+    fitToWindow();                 // each new image starts fit-to-window
+}
+
+void ImageView::showMessage(const QString &text)
+{
+    m_overlay->setText(text);
+    m_overlay->setGeometry(viewport()->rect());
+    m_overlay->show();
+    m_overlay->raise();
+}
+
+void ImageView::fitToWindow()
+{
+    m_fitMode = true;
+    if (m_item) {
+        fitInView(m_item, Qt::KeepAspectRatio);
+        updateSmoothing();
+    }
+}
+
+void ImageView::zoomTo100()
+{
+    if (!m_item)
+        return;
+    m_fitMode = false;
+    resetTransform();
+    const qreal s = 1.0 / deviceScale();   // 1 image px per *physical* px
+    scale(s, s);
+    centerOn(m_item);
+    updateSmoothing();
+}
+
+void ImageView::zoomBy(qreal factor, const QPointF &anchorViewPos)
+{
+    if (!m_item)
+        return;
+    const qreal cur = transform().m11();
+    const qreal fit = fitScale();
+    const qreal maxScale = 8.0 / deviceScale();   // up to 800% actual pixels
+    const qreal lo = qMin(fit, maxScale);
+    const qreal hi = qMax(fit, maxScale);
+    const qreal target = qBound(lo, cur * factor, hi);
+    if (qFuzzyCompare(target, cur))
+        return;
+
+    // Zoom about the cursor: note the scene point currently under it, scale,
+    // then scroll so that same scene point lands back under the cursor. Driven
+    // by the event's own position, so it works on hover with no prior click.
+    const QPointF sceneAnchor = mapToScene(anchorViewPos.toPoint());
+    scale(target / cur, target / cur);
+    const QPointF drift = QPointF(mapFromScene(sceneAnchor)) - anchorViewPos;
+    horizontalScrollBar()->setValue(horizontalScrollBar()->value() + qRound(drift.x()));
+    verticalScrollBar()->setValue(verticalScrollBar()->value() + qRound(drift.y()));
+
+    m_fitMode = (target <= fit * 1.0001);         // snapped back to fit
+    updateSmoothing();
+}
+
+void ImageView::updateSmoothing()
+{
+    if (!m_item)
+        return;
+    // Effective resolution = device pixels per image pixel. At or above 1:1 we
+    // want nearest-neighbour so the user inspects real pixels, not interpolation.
+    const qreal effective = transform().m11() * deviceScale();
+    m_item->setTransformationMode(effective >= 1.0 ? Qt::FastTransformation
+                                                   : Qt::SmoothTransformation);
+}
+
+void ImageView::resizeEvent(QResizeEvent *event)
+{
+    QGraphicsView::resizeEvent(event);
+    if (m_overlay)
+        m_overlay->setGeometry(viewport()->rect());
+    if (m_fitMode)
+        fitToWindow();
+}
+
+void ImageView::wheelEvent(QWheelEvent *event)
+{
+    if (event->modifiers() & (Qt::ControlModifier | Qt::MetaModifier)) {
+        const int dy = event->angleDelta().y();
+        if (dy != 0)
+            zoomBy(dy > 0 ? 1.15 : 1.0 / 1.15, event->position());
+        event->accept();
+    } else {
+        QGraphicsView::wheelEvent(event);   // two-finger scroll pans when zoomed
+    }
+}
+
+bool ImageView::viewportEvent(QEvent *event)
+{
+    if (event->type() == QEvent::NativeGesture) {
+        auto *g = static_cast<QNativeGestureEvent *>(event);
+        if (g->gestureType() == Qt::ZoomNativeGesture) {
+            zoomBy(1.0 + g->value(), g->position());   // trackpad pinch
+            return true;
+        }
+    }
+    return QGraphicsView::viewportEvent(event);
+}
+
+void ImageView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    if (m_fitMode) {
+        // Zoom to 100% anchored on the clicked point, not the image center.
+        const qreal cur = transform().m11();
+        const qreal target = 1.0 / deviceScale();   // 100% actual pixels
+        if (cur > 0.0)
+            zoomBy(target / cur, event->position());
+    } else {
+        fitToWindow();
+    }
+    event->accept();
+}
+
+void ImageView::keyPressEvent(QKeyEvent *event)
+{
+    switch (event->key()) {
+    case Qt::Key_0: fitToWindow(); event->accept(); return;
+    case Qt::Key_1: zoomTo100();   event->accept(); return;
+    case Qt::Key_Plus:
+    case Qt::Key_Equal:  zoomBy(1.25, viewport()->rect().center());       event->accept(); return;
+    case Qt::Key_Minus:  zoomBy(1.0 / 1.25, viewport()->rect().center()); event->accept(); return;
+    default: break;
+    }
+    QGraphicsView::keyPressEvent(event);
+}

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -1,0 +1,53 @@
+// imageview.h
+//
+// A zoomable, pannable image view built on QGraphicsView. It renders at the
+// display's physical pixels (so fit-to-window is full quality on high-DPI
+// screens) and supports trackpad pinch, Cmd/Ctrl+wheel, and double-click to
+// toggle between fit-to-window and 1:1 — where one image pixel maps to one
+// physical device pixel, i.e. actual sensor pixels with no resampling.
+#pragma once
+
+#include <QGraphicsView>
+#include <QString>
+
+class QGraphicsScene;
+class QGraphicsPixmapItem;
+class QLabel;
+class QImage;
+
+class ImageView : public QGraphicsView
+{
+    Q_OBJECT
+public:
+    explicit ImageView(QWidget *parent = nullptr);
+
+    // Show a full-quality image. Resets the view to fit-to-window.
+    void setImage(const QImage &image);
+    // Show centered text (e.g. "Loading…", "No images.") over a blank
+    // background, covering any previous image.
+    void showMessage(const QString &text);
+
+public slots:
+    void fitToWindow();   // scale so the whole image is visible
+    void zoomTo100();     // 1:1 — one image pixel per physical device pixel
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    bool viewportEvent(QEvent *event) override;            // trackpad pinch
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+
+private:
+    qreal deviceScale() const;     // physical pixels per logical pixel (dpr)
+    qreal fitScale() const;        // view scale that fits the whole image
+    // Multiply the current zoom (clamped), keeping the scene point under
+    // anchorViewPos fixed on screen — i.e. zoom about the cursor.
+    void  zoomBy(qreal factor, const QPointF &anchorViewPos);
+    void  updateSmoothing();       // smooth when downscaling, nearest at >=1:1
+
+    QGraphicsScene      *m_scene = nullptr;
+    QGraphicsPixmapItem *m_item = nullptr;
+    QLabel              *m_overlay = nullptr;   // centered message text
+    bool                 m_fitMode = true;
+};

--- a/src/phototriagewindow.cpp
+++ b/src/phototriagewindow.cpp
@@ -7,6 +7,7 @@
 
 #include "phototriagewindow.h"
 #include "imageloader.h"
+#include "imageview.h"
 #include "fileworker.h"
 
 #include <QLabel>
@@ -35,10 +36,8 @@
 #include <QSet>
 #include <QQueue>
 
-// RawLoader provides decoding of RAW photo formats using LibRaw.
-#ifdef HAVE_LIBRAW
-#include "rawloader.h"
-#endif
+// RAW decoding is handled entirely on the worker thread by ImageLoader, so
+// this translation unit no longer needs RawLoader directly.
 #include <cctype>
 #include <QVector>
 
@@ -90,15 +89,14 @@ PhotoTriageWindow::PhotoTriageWindow(QWidget *parent)
     connect(m_fileListWidget, &QListWidget::currentRowChanged,
             this, &PhotoTriageWindow::onFileListSelectionChanged);
 
-    m_imageLabel = new QLabel(this);
-    m_imageLabel->setAlignment(Qt::AlignCenter);
-    m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    m_imageLabel->setStyleSheet("background-color: #111111; color: #E0E0E0;");
+    // Zoomable/pannable image view: renders at physical pixels (sharp on
+    // high-DPI), pinch / Cmd+wheel / double-click to zoom, 1:1 for real pixels.
+    m_imageView = new ImageView(this);
 
     QSplitter *splitter = new QSplitter(this);
     splitter->setOrientation(Qt::Horizontal);
     splitter->addWidget(m_fileListWidget);
-    splitter->addWidget(m_imageLabel);
+    splitter->addWidget(m_imageView);
     splitter->setStretchFactor(0, 0);
     splitter->setStretchFactor(1, 1);
     setCentralWidget(splitter);
@@ -204,7 +202,8 @@ PhotoTriageWindow::~PhotoTriageWindow()
 void PhotoTriageWindow::resizeEvent(QResizeEvent *event)
 {
     QMainWindow::resizeEvent(event);
-    displayCurrentImage();
+    // The image view re-fits itself on resize (see ImageView::resizeEvent),
+    // so there's no need to rebuild the whole display here.
 }
 
 void PhotoTriageWindow::closeEvent(QCloseEvent *event)
@@ -428,6 +427,8 @@ void PhotoTriageWindow::loadSourceDirectory(const QString &directory)
 
     // Reset state
     m_preloaded.clear();
+    m_loading.clear();
+    m_fullRequested.clear();
     m_undoStack.clear();
     m_statusBar->clearMessage();
 
@@ -447,8 +448,7 @@ void PhotoTriageWindow::loadSourceDirectory(const QString &directory)
 void PhotoTriageWindow::displayCurrentImage()
 {
     if (m_currentIndex < 0 || m_currentIndex >= static_cast<int>(m_images.size())) {
-        m_imageLabel->clear();
-        m_imageLabel->setText(tr("No images."));
+        m_imageView->showMessage(tr("No images."));
         m_statusBar->showMessage(QString());
         // Clear selection in file list when there are no images
         if (m_fileListWidget) {
@@ -459,51 +459,35 @@ void PhotoTriageWindow::displayCurrentImage()
         return;
     }
     const QFileInfo &fi = m_images.at(m_currentIndex);
-    QImage image;
     const QString key = fi.absoluteFilePath();
-    // Use preloaded image if available.  Do not remove it from the cache
-    // here; the sliding window in ensurePreloadWindow() manages eviction.  If
-    // the image is not cached, load it synchronously.  Keeping cached
-    // images intact allows rapid back‑and‑forth navigation with minimal
-    // disk I/O.
+
+    // Show the best image we have right now — a full-quality decode, a fast RAW
+    // preview (to be upgraded below), or the thumbnail / a "Loading…" message as
+    // an instant placeholder. The view renders at physical pixels and supports
+    // pinch / 1:1 zoom. We never evict here; ensurePreloadWindow() manages the
+    // sliding window, which keeps back-and-forth navigation (and undo) instant.
     if (m_preloaded.contains(key)) {
-        image = m_preloaded.value(key);
+        m_imageView->setImage(m_preloaded.value(key).image);
+    } else if (m_thumbnailCache.contains(key)) {
+        m_imageView->setImage(m_thumbnailCache.value(key).toImage());
     } else {
-        // Attempt to synchronously load the image.  We try Qt’s loader first;
-        // if that fails and the file is a RAW, fall back to RawLoader.
-        // This mirrors the logic used in ImageLoader but runs on the UI thread.
-        if (!image.load(fi.filePath())) {
-#ifdef HAVE_LIBRAW
-            // Determine whether the extension suggests a RAW file
-            auto isRawExtension = [](const QString &ext) {
-                static const QSet<QString> rawExts = {
-                    QStringLiteral("arw"), QStringLiteral("cr2"), QStringLiteral("cr3"),
-                    QStringLiteral("nef"), QStringLiteral("nrw"), QStringLiteral("raf"),
-                    QStringLiteral("rw2"), QStringLiteral("rwl"), QStringLiteral("orf"),
-                    QStringLiteral("pef"), QStringLiteral("srw"), QStringLiteral("dng"),
-                    QStringLiteral("raw")
-                };
-                return rawExts.contains(ext.toLower());
-            };
-            const QString ext = fi.suffix();
-            if (isRawExtension(ext)) {
-                QImage rawImg;
-                // Try embedded preview first; if that fails use demosaic (half size).
-                if (RawLoader::loadEmbeddedPreview(fi.filePath(), rawImg) ||
-                    RawLoader::loadDemosaiced(fi.filePath(), rawImg, true)) {
-                    image = rawImg;
-                }
-            }
-#endif
-        }
+        m_imageView->showMessage(tr("Loading…"));
     }
-    QPixmap pixmap = QPixmap::fromImage(image);
-    if (!pixmap.isNull()) {
-        QPixmap scaled = pixmap.scaled(m_imageLabel->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-        m_imageLabel->setPixmap(scaled);
-        m_imageLabel->setText(QString());
-    } else {
-        m_imageLabel->setText(tr("Unable to load image"));
+
+    // Ensure the *current* image reaches full display quality: a full-resolution
+    // decode (JPEG) or full demosaic (RAW), off the UI thread, swapped in by
+    // onImagePreloaded(). This runs for a cache miss and for a cached fast RAW
+    // preview alike — but only ever for the image being viewed, never the
+    // prefetch ring (so a RAW folder won't fire many concurrent demosaics).
+    const bool haveFull = m_preloaded.contains(key) && m_preloaded.value(key).full;
+    if (!haveFull && !m_fullRequested.contains(key)) {
+        ImageLoader *ldr = new ImageLoader(m_currentIndex, key, this, QSize(), /*fullQuality=*/true);
+        connect(ldr, &ImageLoader::loaded,
+                this, &PhotoTriageWindow::onImagePreloaded,
+                Qt::QueuedConnection);
+        connect(ldr, &QThread::finished, ldr, &QObject::deleteLater);
+        m_fullRequested.insert(key);
+        ldr->start();
     }
     // Update status bar
     m_statusBar->showMessage(tr("%1/%2 – %3").arg(m_currentIndex + 1).arg(m_images.size()).arg(fi.fileName()));
@@ -548,13 +532,13 @@ void PhotoTriageWindow::ensurePreloadWindow()
     // Preload ahead within the forward window
     for (int i = m_currentIndex + 1; i <= m_currentIndex + PRELOAD_DEPTH && i < m_images.size(); ++i) {
         const QString key = m_images.at(i).absoluteFilePath();
-        if (m_preloaded.contains(key) || m_loading.contains(i)) continue;
-        ImageLoader *ldr = new ImageLoader(i, key, this);
+        if (m_preloaded.contains(key) || m_loading.contains(key)) continue;
+        ImageLoader *ldr = new ImageLoader(i, key, this, QSize(), /*fullQuality=*/false);
         connect(ldr, &ImageLoader::loaded,
                 this,  &PhotoTriageWindow::onImagePreloaded,
                 Qt::QueuedConnection);
         connect(ldr, &QThread::finished, ldr, &QObject::deleteLater);
-        m_loading.insert(i);
+        m_loading.insert(key);
         ldr->start();
     }
     // Optionally preload a small number of images behind the current one to
@@ -562,24 +546,39 @@ void PhotoTriageWindow::ensurePreloadWindow()
     // indices if not already cached or loading.
     for (int i = m_currentIndex - 1; i >= m_currentIndex - PRELOAD_BACK_DEPTH && i >= 0; --i) {
         const QString key = m_images.at(i).absoluteFilePath();
-        if (m_preloaded.contains(key) || m_loading.contains(i)) continue;
-        ImageLoader *ldr = new ImageLoader(i, key, this);
+        if (m_preloaded.contains(key) || m_loading.contains(key)) continue;
+        ImageLoader *ldr = new ImageLoader(i, key, this, QSize(), /*fullQuality=*/false);
         connect(ldr, &ImageLoader::loaded,
                 this,  &PhotoTriageWindow::onImagePreloaded,
                 Qt::QueuedConnection);
         connect(ldr, &QThread::finished, ldr, &QObject::deleteLater);
-        m_loading.insert(i);
+        m_loading.insert(key);
         ldr->start();
     }
 }
 
 
-void PhotoTriageWindow::onImagePreloaded(int index, const QString &path, const QImage &image)
+void PhotoTriageWindow::onImagePreloaded(int index, const QString &path, const QImage &image, bool fullQuality)
 {
-    // Store preloaded image in cache keyed by its absolute path.
-    m_preloaded.insert(path, image);
-    // Remove from loading set by index if present
-    m_loading.remove(index);
+    Q_UNUSED(index);
+    // Store in the cache keyed by absolute path. Never downgrade: a fast RAW
+    // preview must not overwrite a full-quality image already cached.
+    const bool haveFull = m_preloaded.contains(path) && m_preloaded.value(path).full;
+    if (fullQuality) {
+        m_preloaded.insert(path, CachedImage{image, true});
+        m_fullRequested.remove(path);
+    } else if (!haveFull) {
+        m_preloaded.insert(path, CachedImage{image, false});
+    }
+    // Clear the prefetch in-flight marker for this path.
+    m_loading.remove(path);
+    // If this is the image on screen — a fast preview just arrived, the
+    // full-quality upgrade finished, or an un-cached photo was undone — show it
+    // now. displayCurrentImage() also re-requests full quality if still needed.
+    if (m_currentIndex >= 0 && m_currentIndex < static_cast<int>(m_images.size())
+        && m_images.at(m_currentIndex).absoluteFilePath() == path) {
+        displayCurrentImage();
+    }
     ensurePreloadWindow();
 }
 
@@ -709,9 +708,20 @@ void PhotoTriageWindow::performMove(const QString &action)
     actionInfo.originalPath = fi.filePath();
     actionInfo.destinationPath = destPath;
     actionInfo.index = m_currentIndex;
+    // Retain the already-decoded image (and whether it was full quality) so
+    // undo can restore it instantly, skipping the synchronous re-decode that
+    // used to freeze the UI.
+    const CachedImage cached = m_preloaded.value(fi.absoluteFilePath());
+    actionInfo.image = cached.image;
+    actionInfo.imageFull = cached.full;
     m_undoStack.push_back(actionInfo);
     if (static_cast<int>(m_undoStack.size()) > MAX_UNDO) {
         m_undoStack.pop_front();
+    }
+    // Bound memory: keep decoded pixels only for the most recent moves. Deeper
+    // undos fall back to a fast async load via displayCurrentImage().
+    for (int i = 0; i < static_cast<int>(m_undoStack.size()) - UNDO_IMAGE_RETAIN; ++i) {
+        m_undoStack[i].image = QImage();
     }
     // Remove from list
     int removedIndex = m_currentIndex;
@@ -723,8 +733,10 @@ void PhotoTriageWindow::performMove(const QString &action)
     // Remove the cache entry for the file that is being removed
     const QString removedKey = fi.absoluteFilePath();
     m_preloaded.remove(removedKey);
-    // Remove the thumbnail cache entry as well and reset thumbnail loading
-    m_thumbnailCache.remove(removedKey);
+    m_loading.remove(removedKey);
+    m_fullRequested.remove(removedKey);
+    // Keep the thumbnail cached: the file content is unchanged, so if this
+    // image is restored via undo the list row shows its real icon immediately.
     // Update the file list widget: remove the corresponding item instead of
     // rebuilding the entire list.  This keeps UI interactions snappy by
     // avoiding unnecessary iterations.  Guard against null pointer just in case.
@@ -813,16 +825,28 @@ void PhotoTriageWindow::undoLastAction()
     m_images.insert(m_images.begin() + insertIndex, QFileInfo(action.originalPath));
     // Update current index
     m_currentIndex = insertIndex;
-    // Remove any cached entry for this image so it will be reloaded or re‑preloaded as needed
-    m_preloaded.remove(action.originalPath);
-    // Also clear any existing thumbnail for this path so a fresh one will be generated
-    m_thumbnailCache.remove(action.originalPath);
+    // Re-seed the decoded image (if still retained) so the restored photo
+    // paints instantly with no synchronous decode. Key by absolute path to
+    // match the lookup in displayCurrentImage(). If we no longer hold the
+    // pixels, drop any stale entry and let displayCurrentImage() load it
+    // asynchronously (placeholder first, no UI freeze).
+    const QString restoredKey = m_images.at(m_currentIndex).absoluteFilePath();
+    if (!action.image.isNull())
+        m_preloaded.insert(restoredKey, CachedImage{action.image, action.imageFull});
+    else
+        m_preloaded.remove(restoredKey);
+    // Clear any stale in-flight markers so displayCurrentImage() can re-request
+    // a full-quality decode if the retained copy was only a fast RAW preview.
+    m_loading.remove(restoredKey);
+    m_fullRequested.remove(restoredKey);
+    // The thumbnail is kept (file content is unchanged) so the restored row
+    // can show its real icon immediately rather than a generic placeholder.
     // Insert the restored entry into the file list widget instead of rebuilding all items.
     if (m_fileListWidget) {
         static QFileIconProvider iconProvider;
         QListWidgetItem *newItem = new QListWidgetItem();
         newItem->setText(QFileInfo(action.originalPath).fileName());
-        const QString opath = action.originalPath;
+        const QString opath = restoredKey;   // absolute path, matches cache keys
         if (m_thumbnailCache.contains(opath)) {
             newItem->setIcon(QIcon(m_thumbnailCache.value(opath)));
         } else {

--- a/src/phototriagewindow.h
+++ b/src/phototriagewindow.h
@@ -18,6 +18,7 @@ class QLabel;
 class QPushButton;
 class QStatusBar;
 class ImageLoader;
+class ImageView;
 class QListWidget;
 class QAction;
 
@@ -25,12 +26,27 @@ class QAction;
 struct FileTask;
 class FileWorker;
 
+// A decoded image plus whether it is final display quality. For RAW, a fast
+// embedded preview has full == false and gets upgraded to a full demosaic when
+// viewed; non-RAW decodes are always full. Keeping the flag with the pixels
+// means cache eviction can never desync a parallel "is full" set.
+struct CachedImage
+{
+    QImage image;
+    bool   full = false;
+};
+
 // Record of a move operation for undo purposes
 struct MoveAction
 {
     QString originalPath;
     QString destinationPath;
     int index;
+    // Decoded pixels retained so undo can restore the photo instantly without
+    // a synchronous re-decode. May be null (e.g. for older entries, see
+    // UNDO_IMAGE_RETAIN) in which case undo loads it asynchronously.
+    QImage image;
+    bool   imageFull = false;   // was `image` final display quality?
 };
 
 class PhotoTriageWindow : public QMainWindow
@@ -50,7 +66,7 @@ private slots:
     void handleMoveKeep();
     void handleMoveReject();
     void undoLastAction();
-    void onImagePreloaded(int index, const QString &path, const QImage &image);
+    void onImagePreloaded(int index, const QString &path, const QImage &image, bool fullQuality);
 
     // Navigate to the next and previous images without making a keep/reject decision.
     void goToNextImage();
@@ -83,15 +99,25 @@ private:
     // Data
     std::vector<QFileInfo> m_images;
     int m_currentIndex = -1;
-    // Cache of preloaded images keyed by the absolute file path. This
-    // allows the cache to remain valid even when indices shift after
-    // removing items.
-    QHash<QString, QImage> m_preloaded;
+    // Cache of preloaded images keyed by the absolute file path (with a
+    // per-entry "is full quality" flag). Keying by path keeps the cache valid
+    // even when indices shift after removing items.
+    QHash<QString, CachedImage> m_preloaded;
     std::deque<MoveAction> m_undoStack;
     static constexpr int MAX_UNDO = 20;
+    // Retain decoded pixels for only the most recent moves so undo is instant
+    // without holding many full-resolution frames in memory. The common "oops"
+    // undo only needs the last one; deeper undos load asynchronously.
+    static constexpr int UNDO_IMAGE_RETAIN = 3;
 
-    // Preloading queue: indices of images currently loading ahead
-    QSet<int> m_loading;
+    // Absolute paths with a prefetch (fast / preview-quality) load in flight.
+    // Tracked by path (not index) so the guard stays valid across the row
+    // shifts caused by keep/reject/undo.
+    QSet<QString> m_loading;
+    // Absolute paths with a full-quality load in flight for the *current*
+    // image (full RAW demosaic / full decode). Separate from m_loading so a
+    // pending fast preview never blocks the full-quality upgrade.
+    QSet<QString> m_fullRequested;
     static constexpr int PRELOAD_DEPTH = 10;
 
     // Number of images behind the current index to keep preloaded in the
@@ -114,7 +140,7 @@ private:
     QString m_discardDir;
 
     // UI elements
-    QLabel *m_imageLabel;
+    ImageView *m_imageView;
     QStatusBar *m_statusBar;
     QPushButton *m_keepButton;
     QPushButton *m_rejectButton;

--- a/src/rawloader.cpp
+++ b/src/rawloader.cpp
@@ -3,6 +3,7 @@
 #include <libraw/libraw.h>
 #include <QImage>
 #include <QByteArray>
+#include <cstring>   // memcpy
 
 static QImage qimageFromMemImage(const libraw_processed_image_t* img)
 {


### PR DESCRIPTION
Lands this session's work and sets up automated cross-platform releases.

- **Build:** cross-platform CMake (gated Windows .rc, reconfigure-safe LibRaw), macOS support.
- **Undo:** instant (retains the decoded frame; non-blocking display).
- **Viewer:** physical-pixel (high-DPI) rendering, QGraphicsView with pinch / Cmd-scroll zoom, pan, cursor-anchored 1:1; full-resolution RAW for the viewed image.
- **CI:** `.github/workflows/release.yml` - builds self-contained macOS + Windows apps; publishes a GitHub Release on merge to main. This PR runs the build on both platforms **without** releasing, to verify CI before merge.
